### PR TITLE
Add for_each to create multiples node groups

### DIFF
--- a/aws/modules/eks/main.tf
+++ b/aws/modules/eks/main.tf
@@ -62,17 +62,19 @@ module "eks" {
 
   eks_managed_node_group_defaults = {
     disk_size                    = var.disk_size_gb
-    instance_types               = var.instance_type_list
+    instance_types               = var.instance_type
     iam_role_additional_policies = {}
   }
 
   eks_managed_node_groups = {
-    "managed-ng-01" = {
-      min_size       = var.eks_min_instance_node_group
-      max_size       = var.eks_max_instance_node_group
-      desired_size   = var.eks_min_instance_node_group
-      instance_types = var.instance_type_list
-      subnet_ids     = concat(var.private_subnet_ids, var.public_subnet_ids)
+    for name, config in var.eks_node_groups : name => {
+      min_size                   = config.min_size
+      max_size                   = config.max_size
+      desired_size               = config.desired_size
+      instance_types             = config.instance_types
+      subnet_ids                 = concat(var.private_subnet_ids, var.public_subnet_ids)
+      use_custom_launch_template = config.use_custom_launch_template
+      disk_size                  = config.disk_size
       iam_role_additional_policies = {
         managed_policy_arns = "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
       }

--- a/aws/modules/eks/variables.tf
+++ b/aws/modules/eks/variables.tf
@@ -40,19 +40,10 @@ variable "disk_size_gb" {
   type        = string
 }
 
-variable "instance_type_list" {
+variable "instance_type" {
   description = "Lista de tipos de instância permitidos para os grupos de nodes gerenciados."
   type        = list(string)
-}
-
-variable "eks_min_instance_node_group" {
-  description = "Número mínimo de instâncias para os grupos de nodes gerenciados."
-  type        = number
-}
-
-variable "eks_max_instance_node_group" {
-  description = "Número máximo de instâncias para os grupos de nodes gerenciados."
-  type        = number
+  default     = ["t3a.xlarge"]
 }
 
 variable "additional_roles" {
@@ -75,3 +66,14 @@ variable "ebs_service_account_role" {
   type        = string
   default     = null
 }
+
+variable "eks_node_groups" {
+  type = map(object({
+    min_size                   = number
+    max_size                   = number
+    desired_size               = number
+    instance_types             = list(string)
+    disk_size                  = number
+    use_custom_launch_template = bool
+  }))
+} 


### PR DESCRIPTION
Adiciona ao modulo eks a possibilidade de criar mais de 1 node_group no cluster, sem alterar o modulo diretamente.